### PR TITLE
Collision counter

### DIFF
--- a/cell_spawner.tscn
+++ b/cell_spawner.tscn
@@ -17,6 +17,12 @@ z_index = 1
 offset_right = 40.0
 offset_bottom = 23.0
 
+[node name="StatsCounter" type="StatsCounter" parent="."]
+z_index = 2
+offset_right = 40.0
+offset_top = 23.0
+offset_bottom = 46.0
+
 [node name="ViewportBoundaries" type="StaticBody2D" parent="."]
 
 [node name="LeftEdgeBoundary" type="CollisionShape2D" parent="ViewportBoundaries"]

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -4,9 +4,19 @@
 
 using namespace godot;
 
-void Cell::_bind_methods() {}
+void Cell::_bind_methods() {
+    ClassDB::bind_method(D_METHOD("_on_body_entered", "body"), &Cell::_on_body_entered);
+}
+
+int Cell::CollisionCount = 0; 
 
 Cell::Cell() {
+
+    // Setting default required parameters for collision detection on RigidBody2D objects, then applying the signal to Cell objects.
+    this->set_contact_monitor(true);
+    this->set_max_contacts_reported(1000); // Adjust max contacts as complexity increases.
+    this->connect("body_entered", Callable(this, "_on_body_entered"));
+
     rand.instantiate();
     force_magnitude = rand->randf_range(50.0, 150.0);
 
@@ -16,6 +26,7 @@ Cell::Cell() {
 }
 Cell::~Cell() {}
 
+
 void Cell::_process(double delta) {
     // Don't run if in editor
     if (Engine::get_singleton()->is_editor_hint())
@@ -24,4 +35,9 @@ void Cell::_process(double delta) {
     // float direction = rand->randf_range(0, 2 * Math_PI);
     // Vector2 force = Vector2(0, -1).rotated(direction) * speed;
     // apply_force(force);
+}
+
+// function updates on cell contacts. Increments counter for use in stats_counter.cpp
+void Cell::_on_body_entered(Node *body) {
+    CollisionCount++;
 }

--- a/src/cell.hpp
+++ b/src/cell.hpp
@@ -16,6 +16,8 @@ namespace godot {
         Cell();
         ~Cell();
 
+        static int CollisionCount;
+        void _on_body_entered(Node *body);
         void _process(double delta) override;
 
     private:

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -3,6 +3,7 @@
 #include "cell_spawner.hpp"
 #include "cell.hpp"
 #include "fps_counter.hpp"
+#include "stats_counter.hpp"
 
 #include <gdextension_interface.h>
 #include <godot_cpp/core/defs.hpp>
@@ -15,6 +16,7 @@ void initialize_gdextension_module(ModuleInitializationLevel p_level) {
 		return;
 	}
 
+	ClassDB::register_class<StatsCounter>();
 	ClassDB::register_class<FpsCounter>();
 	ClassDB::register_class<Cell>();
 	ClassDB::register_class<CellSpawner>();

--- a/src/stats_counter.cpp
+++ b/src/stats_counter.cpp
@@ -1,0 +1,19 @@
+#include "stats_counter.hpp"
+#include "cell.hpp"
+
+#include <godot_cpp/core/class_db.hpp>
+
+using namespace godot;
+
+void StatsCounter::_bind_methods(){}
+
+StatsCounter::StatsCounter(){}
+StatsCounter::~StatsCounter(){}
+
+void StatsCounter::_process(double delta){
+    // Don't run if in editor
+    if(Engine::get_singleton()->is_editor_hint()) return;
+    
+    const String stats = "COLLISIONS " + String::num(Cell::CollisionCount);
+    set_text(stats);
+}

--- a/src/stats_counter.hpp
+++ b/src/stats_counter.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <godot_cpp/classes/Engine.hpp>
+#include <godot_cpp/classes/Label.hpp>
+
+namespace godot {
+
+  class StatsCounter : public Label { 
+  	GDCLASS(StatsCounter, Label) 
+  
+  protected:
+      static void _bind_methods();
+  
+  public:
+      StatsCounter();
+      ~StatsCounter();
+  
+      void _process(double delta) override;
+  };
+
+}


### PR DESCRIPTION
Added beginner functionality for a statistics readout window. Currently the window only displays statistics on the amount of collisions which have occurred since the programs initialization. The stats_counter.hpp and .cpp files are intended to be expanded on in future iterations.