### PR TITLE
Cell movement, size, and age improvements (CellState)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ bin/*.exp
 bin/*.lib
 .sconsign.dblite
 src/*.obj
+.vscode/
+compile_commands.json

--- a/cell.tscn
+++ b/cell.tscn
@@ -22,3 +22,6 @@ texture = ExtResource("1_544ee")
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource("CircleShape2D_x8tnr")
 debug_color = Color(0, 0.6, 0.701961, 0.419608)
+
+[node name="CellState" type="CellState" parent="."]
+lifespan = 20.0

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -1,27 +1,45 @@
 #include "cell.hpp"
 
 #include <godot_cpp/core/class_db.hpp>
+#include <godot_cpp/classes/sprite2d.hpp>
+#include <godot_cpp/classes/collision_shape2d.hpp>
 
 using namespace godot;
 
-void Cell::_bind_methods() {}
+void Cell::_bind_methods() {
+    ClassDB::bind_method(D_METHOD("apply_scale","scale"), &Cell::applyScale);
+
+    ClassDB::bind_method(D_METHOD("get_scale"), &Cell::getScale);
+    ClassDB::bind_method(D_METHOD("get_sprite_size"), &Cell::getSpriteSize);
+}
 
 Cell::Cell() {
     rand.instantiate();
-    force_magnitude = rand->randf_range(50.0, 150.0);
 
-    float direction = rand->randf_range(0, 2 * Math_PI);
-    Vector2 force = Vector2(0, -1).rotated(direction) * force_magnitude;
-    apply_force(force);
+    _scale = 1;
+    _spriteSize = Size2();
 }
 Cell::~Cell() {}
+
+void Cell::applyScale(float scale) {
+    if (scale <= 0) return;
+
+    this->get_node<CollisionShape2D>("CollisionShape2D")->apply_scale(Vector2(scale, scale));
+    this->get_node<Sprite2D>("Sprite")->apply_scale(Vector2(scale, scale));
+    _scale *= scale;
+    _spriteSize = this->get_node<Sprite2D>("Sprite")->get_rect().size;
+}
+
+float Cell::getScale() const {
+    return _scale;
+}
+
+Size2 Cell::getSpriteSize() const {
+    return _spriteSize;
+}
 
 void Cell::_process(double delta) {
     // Don't run if in editor
     if (Engine::get_singleton()->is_editor_hint())
         return;
-
-    // float direction = rand->randf_range(0, 2 * Math_PI);
-    // Vector2 force = Vector2(0, -1).rotated(direction) * speed;
-    // apply_force(force);
 }

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -1,45 +1,43 @@
 #include "cell.hpp"
 
-#include <godot_cpp/core/class_db.hpp>
-#include <godot_cpp/classes/sprite2d.hpp>
 #include <godot_cpp/classes/collision_shape2d.hpp>
+#include <godot_cpp/classes/sprite2d.hpp>
+#include <godot_cpp/core/class_db.hpp>
 
 using namespace godot;
 
 void Cell::_bind_methods() {
-    ClassDB::bind_method(D_METHOD("apply_scale","scale"), &Cell::applyScale);
+  ClassDB::bind_method(D_METHOD("apply_scale", "scale"), &Cell::applyScale);
 
-    ClassDB::bind_method(D_METHOD("get_scale"), &Cell::getScale);
-    ClassDB::bind_method(D_METHOD("get_sprite_size"), &Cell::getSpriteSize);
+  ClassDB::bind_method(D_METHOD("get_scale"), &Cell::getScale);
+  ClassDB::bind_method(D_METHOD("get_sprite_size"), &Cell::getSpriteSize);
 }
 
 Cell::Cell() {
-    rand.instantiate();
+  rand.instantiate();
 
-    _scale = 1;
-    _spriteSize = Size2();
+  _scale = 1;
+  _spriteSize = Size2();
 }
 Cell::~Cell() {}
 
 void Cell::applyScale(float scale) {
-    if (scale <= 0) return;
+  if (scale <= 0)
+    return;
 
-    this->get_node<CollisionShape2D>("CollisionShape2D")->apply_scale(Vector2(scale, scale));
-    this->get_node<Sprite2D>("Sprite")->apply_scale(Vector2(scale, scale));
-    _scale *= scale;
-    _spriteSize = this->get_node<Sprite2D>("Sprite")->get_rect().size;
+  this->get_node<CollisionShape2D>("CollisionShape2D")
+      ->apply_scale(Vector2(scale, scale));
+  this->get_node<Sprite2D>("Sprite")->apply_scale(Vector2(scale, scale));
+  _scale *= scale;
+  _spriteSize = this->get_node<Sprite2D>("Sprite")->get_rect().size;
 }
 
-float Cell::getScale() const {
-    return _scale;
-}
+float Cell::getScale() const { return _scale; }
 
-Size2 Cell::getSpriteSize() const {
-    return _spriteSize;
-}
+Size2 Cell::getSpriteSize() const { return _spriteSize; }
 
 void Cell::_process(double delta) {
-    // Don't run if in editor
-    if (Engine::get_singleton()->is_editor_hint())
-        return;
+  // Don't run if in editor
+  if (Engine::get_singleton()->is_editor_hint())
+    return;
 }

--- a/src/cell.cpp
+++ b/src/cell.cpp
@@ -6,17 +6,11 @@
 
 using namespace godot;
 
-void Cell::_bind_methods() {
-  ClassDB::bind_method(D_METHOD("apply_scale", "scale"), &Cell::applyScale);
-
-  ClassDB::bind_method(D_METHOD("get_scale"), &Cell::getScale);
-  ClassDB::bind_method(D_METHOD("get_sprite_size"), &Cell::getSpriteSize);
-}
+void Cell::_bind_methods() {}
 
 Cell::Cell() {
   rand.instantiate();
 
-  _scale = 1;
   _spriteSize = Size2();
 }
 Cell::~Cell() {}
@@ -28,16 +22,42 @@ void Cell::applyScale(float scale) {
   this->get_node<CollisionShape2D>("CollisionShape2D")
       ->apply_scale(Vector2(scale, scale));
   this->get_node<Sprite2D>("Sprite")->apply_scale(Vector2(scale, scale));
-  _scale *= scale;
+
+  _cellState->applyScale(scale);
   _spriteSize = this->get_node<Sprite2D>("Sprite")->get_rect().size;
 }
 
-float Cell::getScale() const { return _scale; }
+float Cell::getScale() const { return _cellState->getScale(); }
 
 Size2 Cell::getSpriteSize() const { return _spriteSize; }
+
+void Cell::_ready() { _cellState = this->get_node<CellState>("CellState"); }
 
 void Cell::_process(double delta) {
   // Don't run if in editor
   if (Engine::get_singleton()->is_editor_hint())
     return;
+
+  if (_cellState->getAlive()) {
+    // Living Cell behavior
+
+    // Increment the Cell's age
+    _cellState->incrementAge(delta);
+
+    // Aging and death
+    float ageDiff = _cellState->getAge() - _cellState->getLifespan();
+    if (ageDiff > 0) {
+      // The Cell's age exceeds its lifespan
+
+      // Generate a random number from 0 to the Cell's lifespan times 1 over
+      // delta. If that value is less than ageDiff, kill the Cell. This adds
+      // some variability to Cell lifespans.
+      if (rand->randf_range(0, (1.0 / delta) * _cellState->getLifespan()) <
+          ageDiff) {
+        _cellState->setAlive(false);
+        // Stop Cell movement
+        this->set_linear_damp(10.0);
+      }
+    }
+  }
 }

--- a/src/cell.hpp
+++ b/src/cell.hpp
@@ -6,27 +6,27 @@
 
 namespace godot {
 
-    class Cell : public RigidBody2D {
-        GDCLASS(Cell, RigidBody2D)
+class Cell : public RigidBody2D {
+  GDCLASS(Cell, RigidBody2D)
 
-    protected:
-        static void _bind_methods();
+protected:
+  static void _bind_methods();
 
-    public:
-        Cell();
-        ~Cell();
+public:
+  Cell();
+  ~Cell();
 
-        void applyScale(float scale);
+  void applyScale(float scale);
 
-        float getScale() const;
-        Size2 getSpriteSize() const;
+  float getScale() const;
+  Size2 getSpriteSize() const;
 
-        void _process(double delta) override;
+  void _process(double delta) override;
 
-    private:
-        float _scale;
-        Size2 _spriteSize;
-        Ref<RandomNumberGenerator> rand;
-    };
+private:
+  float _scale;
+  Size2 _spriteSize;
+  Ref<RandomNumberGenerator> rand;
+};
 
-}
+} // namespace godot

--- a/src/cell.hpp
+++ b/src/cell.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "cell_state.hpp"
 
 #include <godot_cpp/classes/Engine.hpp>
 #include <godot_cpp/classes/random_number_generator.hpp>
@@ -16,15 +17,16 @@ public:
   Cell();
   ~Cell();
 
-  void applyScale(float scale);
+  void applyScale(float);
 
   float getScale() const;
   Size2 getSpriteSize() const;
 
-  void _process(double delta) override;
+  void _ready() override;
+  void _process(double) override;
 
 private:
-  float _scale;
+  CellState *_cellState;
   Size2 _spriteSize;
   Ref<RandomNumberGenerator> rand;
 };

--- a/src/cell.hpp
+++ b/src/cell.hpp
@@ -16,10 +16,16 @@ namespace godot {
         Cell();
         ~Cell();
 
+        void applyScale(float scale);
+
+        float getScale() const;
+        Size2 getSpriteSize() const;
+
         void _process(double delta) override;
 
     private:
-        float force_magnitude;
+        float _scale;
+        Size2 _spriteSize;
         Ref<RandomNumberGenerator> rand;
     };
 

--- a/src/cell_spawner.cpp
+++ b/src/cell_spawner.cpp
@@ -43,26 +43,48 @@ int CellSpawner::getNumCells() const {
 }
 
 void CellSpawner::setMinForce(const float minForce) {
-    _minForce = minForce;
+    if (minForce > _maxForce) {
+        _minForce = _maxForce;
+    } else {
+        _minForce = minForce;
+    }
 }
 float CellSpawner::getMinForce() const {
     return _minForce;
 }
 
 void CellSpawner::setMaxForce(const float maxForce) {
-    _maxForce = maxForce;
+    if (maxForce < _minForce) {
+        _maxForce = _minForce;
+    } else {
+        _maxForce = maxForce;
+    }
 }
 float CellSpawner::getMaxForce() const {
     return _maxForce;
 }
 
 void CellSpawner::spawnCell(){
+    // Instantiate cell scene
     Node* cell = _cellScene->instantiate();
+    // Get viewport size for positioning
     Size2 viewportSize = get_viewport()->get_visible_rect().size;
-    Size2 cellSize = cell->get_node<Sprite2D>("Sprite")->get_rect().size;
-    
-    Object::cast_to<Cell>(cell)->set_position(Vector2(rand->randi_range(cellSize.x/4, viewportSize.x - cellSize.x/4),
+    // Cast cell scene to Cell object for ease of use
+    Cell* cellObject = Object::cast_to<Cell>(cell);
+
+    // Set Cell size
+    cellObject->applyScale(rand->randf_range(0.25, 1));
+    Size2 cellSize = cellObject->getSpriteSize();
+
+    // Set Cell position to random location in viewport
+    cellObject->set_position(Vector2(rand->randi_range(cellSize.x/4, viewportSize.x - cellSize.x/4),
         rand->randi_range(cellSize.y/4, viewportSize.y - cellSize.y/4)));
+
+    // Apply random initial force to Cell
+    float force_magnitude = rand->randf_range(_minForce, _maxForce);
+    float direction = rand->randf_range(0, 2 * Math_PI);
+    Vector2 force = Vector2(0, -1).rotated(direction) * force_magnitude;
+    cellObject->apply_force(force);
 
     add_child(cell);
 }

--- a/src/cell_spawner.cpp
+++ b/src/cell_spawner.cpp
@@ -5,95 +5,93 @@
 
 using namespace godot;
 
-void CellSpawner::_bind_methods(){
-    ClassDB::bind_method(D_METHOD("get_num_cells"), &CellSpawner::getNumCells);
-    ClassDB::bind_method(D_METHOD("set_num_cells","num_cells"), &CellSpawner::setNumCells);
-    ClassDB::add_property("CellSpawner",PropertyInfo(Variant::INT,"num_cells"),"set_num_cells","get_num_cells");
+void CellSpawner::_bind_methods() {
+  ClassDB::bind_method(D_METHOD("get_num_cells"), &CellSpawner::getNumCells);
+  ClassDB::bind_method(D_METHOD("set_num_cells", "num_cells"),
+                       &CellSpawner::setNumCells);
+  ClassDB::add_property("CellSpawner", PropertyInfo(Variant::INT, "num_cells"),
+                        "set_num_cells", "get_num_cells");
 
-    ClassDB::bind_method(D_METHOD("get_cell_scene"), &CellSpawner::getCellScene);
-    ClassDB::bind_method(D_METHOD("set_cell_scene","cell_scene"), &CellSpawner::setCellScene);
-    ClassDB::add_property("CellSpawner",PropertyInfo(Variant::OBJECT, "cell_scene"), "set_cell_scene", "get_cell_scene");
+  ClassDB::bind_method(D_METHOD("get_cell_scene"), &CellSpawner::getCellScene);
+  ClassDB::bind_method(D_METHOD("set_cell_scene", "cell_scene"),
+                       &CellSpawner::setCellScene);
+  ClassDB::add_property("CellSpawner",
+                        PropertyInfo(Variant::OBJECT, "cell_scene"),
+                        "set_cell_scene", "get_cell_scene");
 
-    ClassDB::bind_method(D_METHOD("get_min_force"), &CellSpawner::getMinForce);
-    ClassDB::bind_method(D_METHOD("set_min_force","min_force"), &CellSpawner::setMinForce);
-    ClassDB::add_property("CellSpawner",PropertyInfo(Variant::INT, "min_force"), "set_min_force", "get_min_force");
+  ClassDB::bind_method(D_METHOD("get_min_force"), &CellSpawner::getMinForce);
+  ClassDB::bind_method(D_METHOD("set_min_force", "min_force"),
+                       &CellSpawner::setMinForce);
+  ClassDB::add_property("CellSpawner", PropertyInfo(Variant::INT, "min_force"),
+                        "set_min_force", "get_min_force");
 
-    ClassDB::bind_method(D_METHOD("get_max_force"), &CellSpawner::getMaxForce);
-    ClassDB::bind_method(D_METHOD("set_max_force","max_force"), &CellSpawner::setMaxForce);
-    ClassDB::add_property("CellSpawner",PropertyInfo(Variant::INT, "max_force"), "set_max_force", "get_max_force");
+  ClassDB::bind_method(D_METHOD("get_max_force"), &CellSpawner::getMaxForce);
+  ClassDB::bind_method(D_METHOD("set_max_force", "max_force"),
+                       &CellSpawner::setMaxForce);
+  ClassDB::add_property("CellSpawner", PropertyInfo(Variant::INT, "max_force"),
+                        "set_max_force", "get_max_force");
 }
 
-CellSpawner::CellSpawner(){
-    rand.instantiate();
-}
-CellSpawner::~CellSpawner(){}
+CellSpawner::CellSpawner() { rand.instantiate(); }
+CellSpawner::~CellSpawner() {}
 
-void CellSpawner::setCellScene(const Ref<PackedScene> cellScene){
-    _cellScene = cellScene;
+void CellSpawner::setCellScene(const Ref<PackedScene> cellScene) {
+  _cellScene = cellScene;
 }
-Ref<PackedScene> CellSpawner::getCellScene() const{
-    return _cellScene;
-}
+Ref<PackedScene> CellSpawner::getCellScene() const { return _cellScene; }
 
-void CellSpawner::setNumCells(const int numCells){
-    _numCells = numCells;
-}
-int CellSpawner::getNumCells() const {
-    return _numCells;
-}
+void CellSpawner::setNumCells(const int numCells) { _numCells = numCells; }
+int CellSpawner::getNumCells() const { return _numCells; }
 
 void CellSpawner::setMinForce(const float minForce) {
-    if (minForce > _maxForce) {
-        _minForce = _maxForce;
-    } else {
-        _minForce = minForce;
-    }
+  if (minForce > _maxForce) {
+    _minForce = _maxForce;
+  } else {
+    _minForce = minForce;
+  }
 }
-float CellSpawner::getMinForce() const {
-    return _minForce;
-}
+float CellSpawner::getMinForce() const { return _minForce; }
 
 void CellSpawner::setMaxForce(const float maxForce) {
-    if (maxForce < _minForce) {
-        _maxForce = _minForce;
-    } else {
-        _maxForce = maxForce;
-    }
+  if (maxForce < _minForce) {
+    _maxForce = _minForce;
+  } else {
+    _maxForce = maxForce;
+  }
 }
-float CellSpawner::getMaxForce() const {
-    return _maxForce;
+float CellSpawner::getMaxForce() const { return _maxForce; }
+
+void CellSpawner::spawnCell() {
+  // Instantiate cell scene
+  Node *cell = _cellScene->instantiate();
+  // Get viewport size for positioning
+  Size2 viewportSize = get_viewport()->get_visible_rect().size;
+  // Cast cell scene to Cell object for ease of use
+  Cell *cellObject = Object::cast_to<Cell>(cell);
+
+  // Set Cell size
+  cellObject->applyScale(rand->randf_range(0.25, 1));
+  Size2 cellSize = cellObject->getSpriteSize();
+
+  // Set Cell position to random location in viewport
+  cellObject->set_position(Vector2(
+      rand->randi_range(cellSize.x / 4, viewportSize.x - cellSize.x / 4),
+      rand->randi_range(cellSize.y / 4, viewportSize.y - cellSize.y / 4)));
+
+  // Apply random initial force to Cell
+  float force_magnitude = rand->randf_range(_minForce, _maxForce);
+  float direction = rand->randf_range(0, 2 * Math_PI);
+  Vector2 force = Vector2(0, -1).rotated(direction) * force_magnitude;
+  cellObject->apply_force(force);
+
+  add_child(cell);
 }
 
-void CellSpawner::spawnCell(){
-    // Instantiate cell scene
-    Node* cell = _cellScene->instantiate();
-    // Get viewport size for positioning
-    Size2 viewportSize = get_viewport()->get_visible_rect().size;
-    // Cast cell scene to Cell object for ease of use
-    Cell* cellObject = Object::cast_to<Cell>(cell);
+void CellSpawner::_ready() {
+  // Don't run if in editor
+  if (Engine::get_singleton()->is_editor_hint())
+    return;
 
-    // Set Cell size
-    cellObject->applyScale(rand->randf_range(0.25, 1));
-    Size2 cellSize = cellObject->getSpriteSize();
-
-    // Set Cell position to random location in viewport
-    cellObject->set_position(Vector2(rand->randi_range(cellSize.x/4, viewportSize.x - cellSize.x/4),
-        rand->randi_range(cellSize.y/4, viewportSize.y - cellSize.y/4)));
-
-    // Apply random initial force to Cell
-    float force_magnitude = rand->randf_range(_minForce, _maxForce);
-    float direction = rand->randf_range(0, 2 * Math_PI);
-    Vector2 force = Vector2(0, -1).rotated(direction) * force_magnitude;
-    cellObject->apply_force(force);
-
-    add_child(cell);
-}
-
-void CellSpawner::_ready(){
-     // Don't run if in editor
-    if(Engine::get_singleton()->is_editor_hint()) 
-        return;
-    
-    for(int i=0; i<_numCells; ++i) 
-        spawnCell();
+  for (int i = 0; i < _numCells; ++i)
+    spawnCell();
 }

--- a/src/cell_spawner.hpp
+++ b/src/cell_spawner.hpp
@@ -1,47 +1,47 @@
 #pragma once
 
 #include <godot_cpp/classes/Engine.hpp>
+#include <godot_cpp/classes/Viewport.hpp>
 #include <godot_cpp/classes/node.hpp>
 #include <godot_cpp/classes/packed_scene.hpp>
 #include <godot_cpp/classes/random_number_generator.hpp>
 #include <godot_cpp/classes/ref.hpp>
 #include <godot_cpp/classes/sprite2d.hpp>
-#include <godot_cpp/classes/Viewport.hpp>
 
 namespace godot {
 
-class CellSpawner : public Node { 
-	GDCLASS(CellSpawner, Node) 
+class CellSpawner : public Node {
+  GDCLASS(CellSpawner, Node)
 
 protected:
-    static void _bind_methods();
+  static void _bind_methods();
 
 public:
-    CellSpawner();
-    ~CellSpawner();
+  CellSpawner();
+  ~CellSpawner();
 
-    void _ready() override;
+  void _ready() override;
 
-    void setNumCells(const int);
-    int getNumCells() const;
+  void setNumCells(const int);
+  int getNumCells() const;
 
-    void setCellScene(const Ref<PackedScene>);
-    Ref<PackedScene> getCellScene() const;
+  void setCellScene(const Ref<PackedScene>);
+  Ref<PackedScene> getCellScene() const;
 
-    void setMinForce(const float);
-    float getMinForce() const;
+  void setMinForce(const float);
+  float getMinForce() const;
 
-    void setMaxForce(const float);
-    float getMaxForce() const;
+  void setMaxForce(const float);
+  float getMaxForce() const;
 
-    void spawnCell();
+  void spawnCell();
 
 private:
-    Ref<PackedScene> _cellScene;
-    Ref<RandomNumberGenerator> rand;
-    int _numCells = 1;
-    float _minForce = 50.0;
-    float _maxForce = 150.0;
+  Ref<PackedScene> _cellScene;
+  Ref<RandomNumberGenerator> rand;
+  int _numCells = 1;
+  float _minForce = 50.0;
+  float _maxForce = 150.0;
 };
 
-}
+} // namespace godot

--- a/src/cell_spawner.hpp
+++ b/src/cell_spawner.hpp
@@ -20,8 +20,6 @@ public:
   CellSpawner();
   ~CellSpawner();
 
-  void _ready() override;
-
   void setNumCells(const int);
   int getNumCells() const;
 
@@ -35,6 +33,8 @@ public:
   float getMaxForce() const;
 
   void spawnCell();
+
+  void _ready() override;
 
 private:
   Ref<PackedScene> _cellScene;

--- a/src/cell_state.cpp
+++ b/src/cell_state.cpp
@@ -1,0 +1,47 @@
+#include "cell_state.hpp"
+
+using namespace godot;
+
+void CellState::_bind_methods() {
+  ClassDB::bind_method(D_METHOD("set_lifespan", "lifespan"),
+                       &CellState::setLifespan);
+  ClassDB::bind_method(D_METHOD("get_lifespan"), &CellState::getLifespan);
+  ClassDB::add_property("CellState", PropertyInfo(Variant::FLOAT, "lifespan"),
+                        "set_lifespan", "get_lifespan");
+}
+
+CellState::CellState() {
+  _alive = true;
+  _age = 0;
+  _lifespan = 1;
+  _scale = 1;
+}
+CellState::~CellState() {}
+
+void CellState::setAlive(const bool alive) { _alive = alive; }
+bool CellState::getAlive() const { return _alive; }
+
+void CellState::setAge(const float age) {
+  if (age >= 0)
+    _age = age;
+}
+void CellState::incrementAge(const float increment) {
+  if (_age + increment > 0)
+    _age += increment;
+  else
+    _age = 0;
+}
+float CellState::getAge() const { return _age; }
+
+void CellState::setLifespan(const float lifespan) {
+  if (lifespan > 0)
+    _lifespan = lifespan;
+}
+float CellState::getLifespan() const { return _lifespan; }
+
+void CellState::setScale(const float scale) { _scale = scale; }
+void CellState::applyScale(const float scale) {
+  if (scale <= 0)
+    _scale *= scale;
+}
+float CellState::getScale() const { return _scale; }

--- a/src/cell_state.hpp
+++ b/src/cell_state.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <godot_cpp/classes/node.hpp>
+
+namespace godot {
+
+class CellState : public Node {
+  GDCLASS(CellState, Node)
+
+protected:
+  static void _bind_methods();
+
+public:
+  CellState();
+  ~CellState();
+
+  void setAlive(const bool);
+  bool getAlive() const;
+
+  void setAge(const float);
+  void incrementAge(const float);
+  float getAge() const;
+
+  void setLifespan(const float);
+  float getLifespan() const;
+
+  void setScale(const float);
+  void applyScale(const float);
+  float getScale() const;
+
+private:
+  bool _alive;
+  float _age;
+  float _lifespan;
+  float _scale;
+};
+
+}; // namespace godot

--- a/src/fps_counter.cpp
+++ b/src/fps_counter.cpp
@@ -4,15 +4,17 @@
 
 using namespace godot;
 
-void FpsCounter::_bind_methods(){}
+void FpsCounter::_bind_methods() {}
 
-FpsCounter::FpsCounter(){}
-FpsCounter::~FpsCounter(){}
+FpsCounter::FpsCounter() {}
+FpsCounter::~FpsCounter() {}
 
-void FpsCounter::_process(double delta){
-    // Don't run if in editor
-    if(Engine::get_singleton()->is_editor_hint()) return;
-    
-    const String fps = "FPS " + String::num(Engine::get_singleton()->get_frames_per_second());
-    set_text(fps);
+void FpsCounter::_process(double delta) {
+  // Don't run if in editor
+  if (Engine::get_singleton()->is_editor_hint())
+    return;
+
+  const String fps =
+      "FPS " + String::num(Engine::get_singleton()->get_frames_per_second());
+  set_text(fps);
 }

--- a/src/fps_counter.hpp
+++ b/src/fps_counter.hpp
@@ -15,7 +15,7 @@ public:
   FpsCounter();
   ~FpsCounter();
 
-  void _process(double delta) override;
+  void _process(double) override;
 };
 
 } // namespace godot

--- a/src/fps_counter.hpp
+++ b/src/fps_counter.hpp
@@ -5,17 +5,17 @@
 
 namespace godot {
 
-class FpsCounter : public Label { 
-	GDCLASS(FpsCounter, Label) 
+class FpsCounter : public Label {
+  GDCLASS(FpsCounter, Label)
 
 protected:
-    static void _bind_methods();
+  static void _bind_methods();
 
 public:
-    FpsCounter();
-    ~FpsCounter();
+  FpsCounter();
+  ~FpsCounter();
 
-    void _process(double delta) override;
+  void _process(double delta) override;
 };
 
-}
+} // namespace godot

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -2,6 +2,7 @@
 
 #include "cell.hpp"
 #include "cell_spawner.hpp"
+#include "cell_state.hpp"
 #include "fps_counter.hpp"
 
 #include <gdextension_interface.h>
@@ -17,6 +18,7 @@ void initialize_gdextension_module(ModuleInitializationLevel p_level) {
 
   ClassDB::register_class<FpsCounter>();
   ClassDB::register_class<Cell>();
+  ClassDB::register_class<CellState>();
   ClassDB::register_class<CellSpawner>();
 }
 

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -1,7 +1,7 @@
 #include "register_types.hpp"
 
-#include "cell_spawner.hpp"
 #include "cell.hpp"
+#include "cell_spawner.hpp"
 #include "fps_counter.hpp"
 
 #include <gdextension_interface.h>
@@ -11,30 +11,35 @@
 using namespace godot;
 
 void initialize_gdextension_module(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
-		return;
-	}
+  if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
+    return;
+  }
 
-	ClassDB::register_class<FpsCounter>();
-	ClassDB::register_class<Cell>();
-	ClassDB::register_class<CellSpawner>();
+  ClassDB::register_class<FpsCounter>();
+  ClassDB::register_class<Cell>();
+  ClassDB::register_class<CellSpawner>();
 }
 
 void uninitialize_gdextension_module(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
-		return;
-	}
+  if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
+    return;
+  }
 }
 
 extern "C" {
 // Initialization.
-GDExtensionBool GDE_EXPORT library_init(GDExtensionInterfaceGetProcAddress p_get_proc_address, const GDExtensionClassLibraryPtr p_library, GDExtensionInitialization *r_initialization) {
-	godot::GDExtensionBinding::InitObject init_obj(p_get_proc_address, p_library, r_initialization);
+GDExtensionBool GDE_EXPORT
+library_init(GDExtensionInterfaceGetProcAddress p_get_proc_address,
+             const GDExtensionClassLibraryPtr p_library,
+             GDExtensionInitialization *r_initialization) {
+  godot::GDExtensionBinding::InitObject init_obj(p_get_proc_address, p_library,
+                                                 r_initialization);
 
-	init_obj.register_initializer(initialize_gdextension_module);
-	init_obj.register_terminator(uninitialize_gdextension_module);
-	init_obj.set_minimum_library_initialization_level(MODULE_INITIALIZATION_LEVEL_SCENE);
+  init_obj.register_initializer(initialize_gdextension_module);
+  init_obj.register_terminator(uninitialize_gdextension_module);
+  init_obj.set_minimum_library_initialization_level(
+      MODULE_INITIALIZATION_LEVEL_SCENE);
 
-	return init_obj.init();
+  return init_obj.init();
 }
 }


### PR DESCRIPTION
Changes:
- Initial force parameters set in the editor now apply to Cells on creation
- Cells spawn with a size scaled by a random value between 0.25 and 1
- Added a CellState node, which tracks
    - Whether the Cell is alive or not
    - The Cell's age
    - The Cell's lifespan in seconds (this parameter can be set in the editor)
    - The size scaling factor of the Cell
- Cells age as the simulation progresses
- When a Cell's age exceeds its lifespan, it has an increasing chance of dying
- When a Cell dies, it stops moving (it has a high linear damping applied to it)